### PR TITLE
Refactor how manifests are loaded

### DIFF
--- a/src/plugin/Panel/MediaDialog/index.tsx
+++ b/src/plugin/Panel/MediaDialog/index.tsx
@@ -1,6 +1,6 @@
 import { Dialog, Heading, ImageSelect } from "@components";
 import { usePlugin } from "@context";
-import type { CanvasNormalized } from "@iiif/presentation-3-normalized";
+import type { CanvasNormalized, ContentResourceNormalized } from "@iiif/presentation-3-normalized";
 import type { Media } from "@types";
 import { getLabelByUserLanguage } from "@utils";
 import { FC, useEffect, useRef } from "react";
@@ -101,14 +101,15 @@ const Placeholder = () => {
   // it's type, ContentResource, does not include them.
   // To ensure we can access them safely,
   // cast the resource to `any` and then try to access them.
-  function getDimensions(resource: any): { width: number; height: number } {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function getDimensions(resource: any): { height: number; width: number } {
     return {
-      width: resource.width || 0,
       height: resource.height || 0,
+      width: resource.width || 0,
     };
   }
 
-  function formatCaption(resource: any) {
+  function formatCaption(resource: ContentResourceNormalized) {
     const { width, height } = getDimensions(resource);
     const dimensions = width && height ? `\n(${width} x ${height})` : "";
     return `Placeholder${dimensions}`;
@@ -181,14 +182,15 @@ const Thumbnail: FC<{
   // it's type, ContentResource, does not include them.
   // To ensure we can access them safely,
   // cast the resource to `any` and then try to access them.
-  function getDimensions(resource: any): { width: number; height: number } {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function getDimensions(resource: any): { height: number; width: number } {
     return {
-      width: resource.width || 0,
       height: resource.height || 0,
+      width: resource.width || 0,
     };
   }
 
-  function formatCaption(resource: any) {
+  function formatCaption(resource: ContentResourceNormalized) {
     const { width, height } = getDimensions(resource);
     const dimensions = width && height ? `\n(${width} x ${height})` : "";
     return `Thumbnail${dimensions}`;

--- a/src/plugin/Panel/index.tsx
+++ b/src/plugin/Panel/index.tsx
@@ -39,7 +39,7 @@ export function PluginPanelComponent(props: CloverPlugin & PluginProps) {
       type: "setManifest",
       manifest,
     });
-  }, [viewerState.activeManifest, dispatch]);
+  }, [viewerState.activeManifest, state.vault, dispatch]);
 
   useEffect(() => {
     const canvas = state.vault.get({ type: "Canvas", id: viewerState.activeCanvas });
@@ -47,7 +47,7 @@ export function PluginPanelComponent(props: CloverPlugin & PluginProps) {
       type: "setActiveCanvas",
       activeCanvas: canvas,
     });
-  }, [viewerState.activeCanvas, dispatch]);
+  }, [viewerState.activeCanvas, state.vault, dispatch]);
 
   useEffect(() => {
     if (state.manifest) {

--- a/src/plugin/Panel/index.tsx
+++ b/src/plugin/Panel/index.tsx
@@ -1,6 +1,5 @@
 import { Heading, Message, MessagesContainer } from "@components";
 import { PluginContextProvider, usePlugin } from "@context";
-import { upgrade } from "@iiif/parser/upgrader";
 import type { Plugin as CloverPlugin } from "@samvera/clover-iiif";
 import { getLabelByUserLanguage } from "@utils";
 import { useEffect, useState } from "react";
@@ -35,35 +34,20 @@ export function PluginPanelComponent(props: CloverPlugin & PluginProps) {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    (async () => {
-      try {
-        const response = await fetch(viewerState.activeManifest);
-        const json = await response.json();
-        const manifest = upgrade(json);
-        if (manifest.type === "Manifest") {
-          dispatch({
-            type: "setManifest",
-            manifest: manifest,
-          });
-        }
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error("Error fetching manifest:", error);
-      }
-    })();
+    const manifest = state.vault.get({ type: "Manifest", id: viewerState.activeManifest });
+    dispatch({
+      type: "setManifest",
+      manifest,
+    });
   }, [viewerState.activeManifest, dispatch]);
 
   useEffect(() => {
-    if (state.manifest) {
-      const activeCanvas = state.manifest.items.find(
-        (canvas) => canvas.id === viewerState.activeCanvas,
-      );
-      dispatch({
-        type: "setActiveCanvas",
-        activeCanvas: activeCanvas || undefined,
-      });
-    }
-  }, [viewerState.activeCanvas, state.manifest, dispatch]);
+    const canvas = state.vault.get({ type: "Canvas", id: viewerState.activeCanvas });
+    dispatch({
+      type: "setActiveCanvas",
+      activeCanvas: canvas,
+    });
+  }, [viewerState.activeCanvas, dispatch]);
 
   useEffect(() => {
     if (state.manifest) {
@@ -119,7 +103,7 @@ export function PluginPanelComponent(props: CloverPlugin & PluginProps) {
 
 export function PluginPanel(props: CloverPlugin & PluginProps) {
   return (
-    <PluginContextProvider>
+    <PluginContextProvider clover={props}>
       <PluginPanelComponent {...props} />
     </PluginContextProvider>
   );

--- a/src/plugin/context/plugin-context.tsx
+++ b/src/plugin/context/plugin-context.tsx
@@ -89,7 +89,7 @@ export type PluginContextActions =
   | SetVaultAction
   | SystemPromptAction;
 
-/** Default values not inherited from the Clvoer Viewer */
+/** Default values not inherited from the Clover Viewer */
 type InitPluginContextStore = Omit<PluginContextStore, "vault" | "activeCanvas" | "manifest">;
 
 const defaultPluginContextStore: InitPluginContextStore = {

--- a/src/plugin/context/plugin-context.tsx
+++ b/src/plugin/context/plugin-context.tsx
@@ -165,11 +165,11 @@ function pluginReducer(
 }
 
 export const PluginContextProvider = ({
-  clover,
   children,
+  clover,
 }: {
-  clover: CloverIIIF;
   children: React.ReactNode;
+  clover: CloverIIIF;
 }) => {
   const { useViewerState } = clover;
   const viewerState = useViewerState();

--- a/src/plugin/context/plugin-context.tsx
+++ b/src/plugin/context/plugin-context.tsx
@@ -1,4 +1,6 @@
-import type { Canvas, Manifest } from "@iiif/presentation-3";
+import type { Vault } from "@iiif/helpers";
+import type { CanvasNormalized, ManifestNormalized } from "@iiif/presentation-3-normalized";
+import type { Plugin as CloverIIIF } from "@samvera/clover-iiif";
 import type { ConversationState, Media, Message } from "@types";
 import { loadMessagesFromStorage, setMessagesToStorage } from "@utils";
 import type { Viewer } from "openseadragon";
@@ -7,15 +9,16 @@ import { createContext, useContext, useReducer } from "react";
 import type { BaseProvider } from "../base_provider";
 
 export interface PluginContextStore {
-  activeCanvas: Canvas | undefined;
+  activeCanvas: CanvasNormalized;
   conversationState: ConversationState;
-  manifest: Manifest | undefined;
+  manifest: ManifestNormalized;
   mediaDialogState: "closed" | "open";
   messages: Message[];
   openSeaDragonViewer: Viewer | undefined;
   provider: BaseProvider | undefined;
   selectedMedia: Media[];
   systemPrompt: string;
+  vault: Vault;
 }
 
 interface AddMessageAction {
@@ -29,7 +32,7 @@ interface ClearConversation {
 }
 
 interface SetActiveCanvasAction {
-  activeCanvas: Canvas | undefined;
+  activeCanvas: CanvasNormalized;
   type: "setActiveCanvas";
 }
 
@@ -39,7 +42,7 @@ interface SetConversationState {
 }
 
 interface SetManifestAction {
-  manifest: Manifest | undefined;
+  manifest: ManifestNormalized;
   type: "setManifest";
 }
 
@@ -58,6 +61,11 @@ interface SetSelectedMediaAction {
   type: "setSelectedMedia";
 }
 
+interface SetVaultAction {
+  vault: Vault;
+  type: "setVault";
+}
+
 interface SystemPromptAction {
   systemPrompt: string;
   type: "setSystemPrompt";
@@ -69,7 +77,6 @@ interface UpdateProviderAction {
 }
 
 export type PluginContextActions =
-  | SystemPromptAction
   | AddMessageAction
   | ClearConversation
   | UpdateProviderAction
@@ -78,21 +85,29 @@ export type PluginContextActions =
   | SetActiveCanvasAction
   | SetMediaDialogStateAction
   | SetSelectedMediaAction
-  | SetOSDViewerAction;
+  | SetOSDViewerAction
+  | SetVaultAction
+  | SystemPromptAction;
 
-const defaultPluginContextStore: PluginContextStore = {
-  systemPrompt: "",
-  messages: [],
-  provider: undefined,
+/** Default values not inherited from the Clvoer Viewer */
+type InitPluginContextStore = Omit<PluginContextStore, "vault" | "activeCanvas" | "manifest">;
+
+const defaultPluginContextStore: InitPluginContextStore = {
   conversationState: "idle",
   mediaDialogState: "closed",
-  selectedMedia: [],
-  manifest: undefined,
-  activeCanvas: undefined,
+  messages: [],
   openSeaDragonViewer: undefined,
+  provider: undefined,
+  selectedMedia: [],
+  systemPrompt: "",
 };
 
-const PluginStateContext = createContext<PluginContextStore>(defaultPluginContextStore);
+const PluginStateContext = createContext<PluginContextStore>(
+  // the context needs to be initialized with some value,
+  // but in order to avoid a bunch of undefined checks,
+  // we cast it as a PluginContextStore and then set Clover values in the PluginContextProvider
+  defaultPluginContextStore as PluginContextStore,
+);
 const PluginDispatchContext = createContext<Dispatch<PluginContextActions> | null>(null);
 
 function pluginReducer(
@@ -141,19 +156,32 @@ function pluginReducer(
       return { ...state, selectedMedia: action.selectedMedia };
     case "setOpenSeaDragonViewer":
       return { ...state, openSeaDragonViewer: action.openSeaDragonViewer };
+    case "setVault":
+      return { ...state, vault: action.vault };
     default:
       //@ts-expect-error - this is a catch-all for unknown action types
       throw new Error(`Unknown action type: ${action.type}`);
   }
 }
 
-export const PluginContextProvider = ({ children }: { children: React.ReactNode }) => {
+export const PluginContextProvider = ({
+  clover,
+  children,
+}: {
+  clover: CloverIIIF;
+  children: React.ReactNode;
+}) => {
+  const { useViewerState } = clover;
+  const viewerState = useViewerState();
   // Initialize state with messages from session storage if available
   const getInitialState = (): PluginContextStore => {
     const storedMessages = loadMessagesFromStorage();
     return {
       ...defaultPluginContextStore,
+      manifest: viewerState.vault.get({ type: "Manifest", id: viewerState.activeManifest }),
+      activeCanvas: viewerState.vault.get({ type: "Canvas", id: viewerState.activeCanvas }),
       messages: storedMessages,
+      vault: viewerState.vault,
     };
   };
 

--- a/src/plugin/utils/index.ts
+++ b/src/plugin/utils/index.ts
@@ -1,7 +1,10 @@
-import type { InternationalString } from "@iiif/presentation-3";
+import type { ManifestNormalized } from "@iiif/presentation-3-normalized";
 import type { Message } from "@types";
 
-export function getLabelByUserLanguage(label: InternationalString): string[] {
+export function getLabelByUserLanguage(label: ManifestNormalized["label"]): string[] {
+  if (!label) {
+    return [];
+  }
   const userLangs = navigator.languages || [navigator.language];
   const lang = userLangs.find((l) => label[l]) || "none";
   const titles = label[lang] ? label[lang] : [];


### PR DESCRIPTION
## Description

This refactors how the activeManifest and activeCanvas are loaded.

- there is a new property for a `vault`
- the state.manifest and state.activeCanvas are no longer `undefined`
- when the plugin is initialized, the `manifest`, `activeCanvas`, and `vault` are injected from Clover