### PR TITLE
feat: add canvas paintaings to media dialog

### DIFF
--- a/src/plugin/Panel/MediaDialog/index.tsx
+++ b/src/plugin/Panel/MediaDialog/index.tsx
@@ -1,8 +1,9 @@
 import { Dialog, Heading, ImageSelect } from "@components";
 import { usePlugin } from "@context";
-import type { CanvasNormalized, ContentResourceNormalized } from "@iiif/presentation-3-normalized";
+import { serializeConfigPresentation3, Traverse } from "@iiif/parser";
+import type { Canvas, ContentResource } from "@iiif/presentation-3";
 import type { Media } from "@types";
-import { getLabelByUserLanguage } from "@utils";
+import { getLabelByUserLanguage, updateIIIFImageRequestURI } from "@utils";
 import { FC, useEffect, useRef } from "react";
 import style from "./style.module.css";
 
@@ -21,6 +22,37 @@ function handleSelectedMedia(
     : selectedMedia.filter((m) => m.id !== media.id);
 
   onUpdate(resources);
+}
+
+// Though the resource may have `width` and `height` properties
+// it's type does not include them.
+// To ensure we can access them safely, without excessive type checking,
+// cast the resource to `any` and then try to access them.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getDimensions(resource: any): { height: number; width: number } {
+  return {
+    height: resource?.height || 0,
+    width: resource?.width || 0,
+  };
+}
+
+/**
+ * Format a caption string for a IIIF resource including its dimensions if available.
+ *
+ * @param topline the top line of the caption, e.g. "Thumbnail"
+ * @param resource the IIIF resource to get dimensions from
+ * @returns a formatted caption string
+ *
+ * @example
+ * ```ts
+ * formatCaption("Thumbnail", resource);
+ * // "Thumbnail\n(100 x 200)"
+ * ``
+ */
+function formatCaption(topline: string, resource: ContentResource) {
+  const { width, height } = getDimensions(resource);
+  const dimensions = width && height ? `\n(${width} x ${height})` : "";
+  return topline + dimensions;
 }
 
 const CurrentView = () => {
@@ -88,89 +120,76 @@ const CurrentView = () => {
   );
 };
 
-const Placeholder = () => {
+const Paintings: FC<{ canvas: Canvas }> = ({ canvas }) => {
   const { state, dispatch } = usePlugin();
 
   function handleAddMedia(selected: boolean, media: Media) {
+    // when adding the media, update the size to be max
+    media.src = updateIIIFImageRequestURI(media.src, {
+      size: `max`,
+    });
     handleSelectedMedia(selected, media, state.selectedMedia, (resources) =>
       dispatch({ type: "setSelectedMedia", selectedMedia: resources }),
     );
   }
 
-  // Though the resource may have `width` and `height` properties
-  // it's type, ContentResource, does not include them.
-  // To ensure we can access them safely,
-  // cast the resource to `any` and then try to access them.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function getDimensions(resource: any): { height: number; width: number } {
-    return {
-      height: resource.height || 0,
-      width: resource.width || 0,
-    };
-  }
+  const paintings: ContentResource[] = [];
+  const traverse = new Traverse({
+    contentResource: [
+      (resource) => {
+        if (resource.type === "Image") {
+          paintings.push(resource);
+        }
+      },
+    ],
+  });
+  traverse.traverseCanvasItems(canvas);
 
-  function formatCaption(resource: ContentResourceNormalized) {
-    const { width, height } = getDimensions(resource);
-    const dimensions = width && height ? `\n(${width} x ${height})` : "";
-    return `Placeholder${dimensions}`;
-  }
-
-  const activeCanvas = state.activeCanvas;
-
-  if (!activeCanvas.placeholderCanvas) {
+  if (!paintings.length) {
     return <></>;
   }
 
-  const placeholderResource = state.vault.get({
-    type: "Canvas",
-    id: activeCanvas.placeholderCanvas.id,
-  });
+  const media: Media[] = paintings.reduce((acc, painting, i) => {
+    if (!painting.id) {
+      return acc;
+    }
 
-  const annotationItems = state.vault.get({
-    type: "AnnotationPage",
-    id: placeholderResource.items.map((item) => item.id),
-  });
+    // @ts-expect-error - I don't want to go down the rabbit hole of type checking here
+    const label = getLabelByUserLanguage(painting?.label);
+    acc.push({
+      type: "image",
+      id: `painting-${i}`,
+      // use a smaller size so as to not load large images
+      // update the size when the media is added
+      src: updateIIIFImageRequestURI(painting.id, {
+        size: "!300,300",
+      }),
+      caption: formatCaption(label[0] ? label[0] : "Painting", painting),
+    });
 
-  const annotationPageItems = state.vault.get({
-    type: "Annotation",
-    id: annotationItems.items.map((item) => item.id),
-  });
-
-  const body = state.vault.get({
-    type: "ContentResource",
-    id: annotationPageItems.body.map((b) => b.id),
-  });
-
-  const id = body.id;
-  const paintingMedia: Media = {
-    type: "image",
-    id: id || "",
-    src: id || "",
-    caption: formatCaption(body),
-  };
+    return acc;
+  }, [] as Media[]);
 
   return (
     <>
-      {id && (
+      {media.map((m) => (
         <ImageSelect
-          figcaption={paintingMedia.caption}
-          imgObjectFit="contain"
-          src={id}
-          initialState={
-            isMediaInSelectedMedia(paintingMedia, state.selectedMedia) ? "selected" : "unselected"
-          }
-          onSelectionChange={(selected) => handleAddMedia(selected, paintingMedia)}
+          figcaption={m.caption}
+          imgObjectFit="cover"
+          initialState={isMediaInSelectedMedia(m, state.selectedMedia) ? "selected" : "unselected"}
+          key={m.id}
+          src={m.src}
+          onSelectionChange={(selected) => handleAddMedia(selected, m)}
         />
-      )}
+      ))}
     </>
   );
 };
 
-const Thumbnail: FC<{
-  thumbnail: CanvasNormalized["thumbnail"][0];
-}> = ({ thumbnail }) => {
+const Placeholder: FC<{ placeholder: NonNullable<Canvas["placeholderCanvas"]> }> = ({
+  placeholder,
+}) => {
   const { state, dispatch } = usePlugin();
-  const resource = state.vault.get({ type: "ContentResource", id: thumbnail.id });
 
   function handleAddMedia(selected: boolean, media: Media) {
     handleSelectedMedia(selected, media, state.selectedMedia, (resources) =>
@@ -178,44 +197,88 @@ const Thumbnail: FC<{
     );
   }
 
-  // Though the resource may have `width` and `height` properties
-  // it's type, ContentResource, does not include them.
-  // To ensure we can access them safely,
-  // cast the resource to `any` and then try to access them.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function getDimensions(resource: any): { height: number; width: number } {
-    return {
-      height: resource.height || 0,
-      width: resource.width || 0,
-    };
+  const paintings: ContentResource[] = [];
+  const traverse = new Traverse({
+    contentResource: [
+      (resource) => {
+        if (resource.type === "Image") {
+          paintings.push(resource);
+        }
+      },
+    ],
+  });
+  traverse.traverseCanvasItems(placeholder);
+
+  if (!paintings.length) {
+    return <></>;
   }
 
-  function formatCaption(resource: ContentResourceNormalized) {
-    const { width, height } = getDimensions(resource);
-    const dimensions = width && height ? `\n(${width} x ${height})` : "";
-    return `Thumbnail${dimensions}`;
-  }
+  const media: Media[] = paintings.reduce((acc, painting, i) => {
+    if (!painting.id) {
+      return acc;
+    }
 
-  const id = thumbnail.id;
-  const thumbnailMedia: Media = {
-    type: "image",
-    id: id || "",
-    src: id || "",
-    caption: formatCaption(resource),
-  };
+    acc.push({
+      type: "image",
+      id: `placeholder-${i}`,
+      src: painting.id,
+      caption: formatCaption("Placeholder", painting),
+    });
+
+    return acc;
+  }, [] as Media[]);
 
   return (
     <>
-      {id && (
+      {media.map((m) => (
         <ImageSelect
-          figcaption={thumbnailMedia.caption}
-          src={thumbnailMedia.src}
-          initialState={
-            isMediaInSelectedMedia(thumbnailMedia, state.selectedMedia) ? "selected" : "unselected"
-          }
-          onSelectionChange={(selected) => handleAddMedia(selected, thumbnailMedia)}
+          figcaption={m.caption}
+          imgObjectFit="cover"
+          initialState={isMediaInSelectedMedia(m, state.selectedMedia) ? "selected" : "unselected"}
+          key={m.id}
+          src={m.src}
+          onSelectionChange={(selected) => handleAddMedia(selected, m)}
         />
-      )}
+      ))}
+    </>
+  );
+};
+
+const Thumbnails: FC<{ thumbnails: ContentResource[] }> = ({ thumbnails }) => {
+  const { state, dispatch } = usePlugin();
+
+  function handleAddMedia(selected: boolean, media: Media) {
+    handleSelectedMedia(selected, media, state.selectedMedia, (resources) =>
+      dispatch({ type: "setSelectedMedia", selectedMedia: resources }),
+    );
+  }
+
+  const media: Media[] = thumbnails.reduce((acc, thumbnail, i) => {
+    if (!thumbnail.id) {
+      return acc;
+    }
+    acc.push({
+      type: "image",
+      id: `thumbnail-${i}`,
+      src: thumbnail.id,
+      caption: formatCaption("Thumbnail", thumbnail),
+    });
+    return acc;
+  }, [] as Media[]);
+
+  return (
+    <>
+      {media.map((thumbnail, index) => (
+        <ImageSelect
+          figcaption={thumbnail.caption}
+          key={index}
+          src={thumbnail.src}
+          initialState={
+            isMediaInSelectedMedia(thumbnail, state.selectedMedia) ? "selected" : "unselected"
+          }
+          onSelectionChange={(selected) => handleAddMedia(selected, thumbnail)}
+        />
+      ))}
     </>
   );
 };
@@ -224,7 +287,7 @@ export const MediaDialog = () => {
   const { state, dispatch } = usePlugin();
   const dialogRef = useRef<HTMLDialogElement>(null);
   const initialFocusRef = useRef<HTMLDivElement>(null);
-  const canvasTitle = getLabelByUserLanguage(state.activeCanvas.label)[0];
+  const canvasTitle = getLabelByUserLanguage(state.activeCanvas?.label ?? undefined)[0];
 
   function closeDialog() {
     dispatch({ type: "setMediaDialogState", state: "closed" });
@@ -260,6 +323,14 @@ export const MediaDialog = () => {
     };
   }, [state.mediaDialogState, dispatch]);
 
+  // serialize the Canvas so it can traversed
+  const canvas: Canvas = state.vault.serialize(
+    { type: "Canvas", id: state.activeCanvas.id },
+    serializeConfigPresentation3,
+  );
+
+  // NOTE: It is assumed that all media resources are images hosted on the internet
+  // and that they can be used directly as the `src` for an `<img>` element.
   return (
     <Dialog
       aria-modal="true"
@@ -284,14 +355,9 @@ export const MediaDialog = () => {
           <div className={style.contentContainer}>
             <div className={style.content}>
               <CurrentView />
-              <Placeholder />
-              {state.activeCanvas.thumbnail.length > 0 && (
-                <>
-                  {state.activeCanvas.thumbnail.map((thumbnail, i) => (
-                    <Thumbnail key={`thumbnail-${i}`} thumbnail={thumbnail} />
-                  ))}
-                </>
-              )}
+              <Paintings canvas={canvas} />
+              {canvas.placeholderCanvas && <Placeholder placeholder={canvas.placeholderCanvas} />}
+              {canvas.thumbnail?.length && <Thumbnails thumbnails={canvas.thumbnail} />}
             </div>
           </div>
         </>

--- a/src/plugin/Panel/MediaDialog/style.module.css
+++ b/src/plugin/Panel/MediaDialog/style.module.css
@@ -16,10 +16,9 @@
 }
 
 .content {
-  /* display: grid; */
-  /* grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); */
   display: flex;
   gap: var(--clover-ai-sizes-2);
+  flex-wrap: wrap;
 
   figcaption {
     --figure-caption-font-size: var(--clover-ai-sizes-3);

--- a/src/plugin/Panel/index.test.tsx
+++ b/src/plugin/Panel/index.test.tsx
@@ -70,6 +70,23 @@ const mockClover = {
           };
         return null;
       }),
+      serialize: vi.fn((query) => {
+        if (query.type === "Canvas")
+          return {
+            id: "canvas-1",
+            type: "Canvas",
+            label: { en: ["Test Canvas"] },
+            thumbnail: [
+              {
+                id: "thumbnail-1",
+                type: "Image",
+                format: "image/jpeg",
+              },
+            ],
+            items: [],
+          };
+        return null;
+      }),
     },
     activeManifest: "manifest-1",
     activeCanvas: "canvas-1",

--- a/src/plugin/utils/index.ts
+++ b/src/plugin/utils/index.ts
@@ -1,7 +1,7 @@
-import type { ManifestNormalized } from "@iiif/presentation-3-normalized";
+import { InternationalString } from "@iiif/presentation-3";
 import type { Message } from "@types";
 
-export function getLabelByUserLanguage(label: ManifestNormalized["label"]): string[] {
+export function getLabelByUserLanguage(label: InternationalString | undefined): string[] {
   if (!label) {
     return [];
   }
@@ -49,4 +49,109 @@ export function setMessagesToStorage(messages: Message[]): void {
     // eslint-disable-next-line no-console
     console.warn("Failed to save messages to session storage:", error);
   }
+}
+
+type Scheme = "http" | "https" | (string & {});
+/** @example "example.org" */
+type Server = string;
+/**
+ * @remarks
+ * If not empty, must start with a leading slash and not end with a trailing slash.
+ *
+ * @example "/iiif" */
+type Prefix = `/${string}` | "";
+/** @example "image1" */
+type Identifier = string;
+/** @example "full", "x,y,w,h" */
+type Region = string;
+/** @example "max", "w,", ",h", "pct:n" */
+type Size = string;
+/** @example "0", "90", "!90" */
+type Rotation = string;
+/** @example "default", "color", "gray", "bitonal" */
+type Quality = string;
+/** @example "jpg", "png", "tif" */
+type Format = string;
+
+/**
+ * A IIIF Image Request URI as defined in the IIIF Image API 3.0 specification.
+ *
+ * @example
+ * "https://example.org/iiif/image1/full/max/0/default.jpg"
+ */
+export type IIIFImageRequestURI =
+  `${Scheme}://${Server}${Prefix}/${Identifier}/${Region}/${Size}/${Rotation}/${Quality}.${Format}`;
+
+export interface IIIFImageRequestParams {
+  scheme: Scheme;
+  server: Server;
+  prefix: Prefix;
+  identifier: Identifier;
+  region: Region;
+  size: Size;
+  rotation: Rotation;
+  quality: Quality;
+  format: Format;
+}
+
+/**
+ * Create a IIIF Image Request URI from its components.
+ *
+ */
+export function createIIIFImageRequestURI({
+  scheme = "https",
+  server,
+  prefix = "",
+  identifier,
+  region = "full",
+  size = "max",
+  rotation = "0",
+  quality = "default",
+  format = "jpg",
+}: Partial<IIIFImageRequestParams>): IIIFImageRequestURI {
+  return `${scheme}://${server}${prefix}/${identifier}/${region}/${size}/${rotation}/${quality}.${format}`;
+}
+
+/**
+ * Update parts of a IIIF Image Request URI while preserving the other components.
+ *
+ * @param baseURI a IIIF Image Request URI containing at least the server and identifier
+ * @param updates the parts of the URI to update
+ */
+export function updateIIIFImageRequestURI(
+  baseURI: string,
+  updates: Partial<IIIFImageRequestParams>,
+): IIIFImageRequestURI {
+  const url = new URL(baseURI);
+  const originalParts = url.pathname.split("/").filter((part) => part);
+
+  // work backwards to pop off the known parts
+  const qualityAndFormat = originalParts.pop()?.split(".") ?? [];
+  const quality = qualityAndFormat[0];
+  const format = qualityAndFormat[1];
+  const rotation = originalParts.pop();
+  const size = originalParts.pop();
+  const region = originalParts.pop();
+  const identifier = originalParts.pop();
+  const prefix = originalParts.join("/");
+
+  if (!identifier) {
+    throw new Error("Invalid IIIF Image Request URI: Missing identifier");
+  }
+
+  if (!url.host) {
+    throw new Error("Invalid IIIF Image Request URI: Missing server");
+  }
+
+  return createIIIFImageRequestURI({
+    scheme: url?.protocol?.replace(":", "") ?? "https",
+    server: url.host,
+    prefix: updates.prefix ?? (prefix ? `/${prefix}` : ""),
+    identifier: updates.identifier ?? identifier,
+    region: updates.region ?? region,
+    size: updates.size ?? size,
+    rotation: updates.rotation ?? rotation,
+    quality: updates.quality ?? quality,
+    format: updates.format ?? format,
+  });
 }


### PR DESCRIPTION
The PR:

- adds the representative Canvas images to the MediaDialog component
- makes use of the Traverse class to find items more succinctly